### PR TITLE
Corrected audit trail if no git repo and added wrapper for iRODS

### DIFF
--- a/bin/general_juno_pipeline.py
+++ b/bin/general_juno_pipeline.py
@@ -165,10 +165,19 @@ class RunSnakemake:
         self.run_snakemake()
 
 
+    def is_not_repo(self):
+        git_remote = subprocess.check_output(["git","remote", "-v"])
+        return git_remote == b''
+        
     def get_git_audit(self, git_file):
         print_message("Collecting information about the Git repository of this pipeline (see {})".format(git_file))
-        git_audit = {"repo": subprocess.check_output(["git","config", "--get", "remote.origin.url"]).strip(),
-                    "commit": subprocess.check_output(["git","log", "-n", "1" "--pretty=format:'%H'"]).strip()}
+        if not self.is_not_repo():
+            git_audit = {"repo": subprocess.check_output(["git","config", "--get", "remote.origin.url"]).strip(),
+                        "commit": subprocess.check_output(["git","log", "-n", "1" "--pretty=format:'%H'"]).strip()}
+        else:
+            git_audit = {"repo": "NA (folder is not a repo or was not cloned through git command)",
+                        "commit": "NA (folder is not a repo or was not cloned through git command)"}
+
         with open(git_file, 'w') as file:
             yaml.dump(git_audit, file, default_flow_style=False)
 

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -1,0 +1,35 @@
+# Wrapper for juno typing pipeline
+
+#----------------------------------------------#
+# Create/update necessary environments
+PATH_MAMBA_YAML="envs/mamba.yaml"
+PATH_MASTER_YAML="envs/master_env.yaml"
+MAMBA_NAME=$(head -n 1 ${PATH_MAMBA_YAML} | cut -f2 -d ' ')
+MASTER_NAME=$(head -n 1 ${PATH_MASTER_YAML} | cut -f2 -d ' ')
+
+envs_list=$(conda env list)
+
+if ! $(echo $envs_list | grep -q mamba)
+then
+    conda env update -f "${PATH_MAMBA_YAML}"
+fi
+
+source activate "${MAMBA_NAME}"
+
+if ! $(echo $envs_list | grep -q seroba_master)
+then
+    mamba env update -f "${PATH_MASTER_YAML}"
+fi
+
+source activate "${MASTER_NAME}"
+
+#----------------------------------------------#
+# Run the pipeline
+
+if [ ! -z ${irods_runsheet_sys__runsheet__lsf_queue} ]; then
+    QUEUE="${irods_runsheet_sys__runsheet__lsf_queue}"
+else
+    QUEUE="bio"
+fi
+
+python juno_typing.py --queue "${QUEUE}" ${@}


### PR DESCRIPTION
Preventing error in audit trail if github repo was downloaded and it is not a git repo and added a wrapper (run_pipeline.sh) for iRODS at RIVM