### PR TITLE
ST3075 fix

### DIFF
--- a/.github/workflows/juno_typing_test.yaml
+++ b/.github/workflows/juno_typing_test.yaml
@@ -23,6 +23,7 @@ jobs:
         with:
           cache-downloads: true
           environment-file: envs/master_env.yaml
+          channel-priority: false
       - name: Conda list
         shell: bash -l {0}
         run: conda list

--- a/.github/workflows/juno_typing_test.yaml
+++ b/.github/workflows/juno_typing_test.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           cache-downloads: true
           environment-file: envs/master_env.yaml
-          channel-priority: false
+          channel-priority: true
       - name: Conda list
         shell: bash -l {0}
         run: conda list

--- a/.github/workflows/juno_typing_test.yaml
+++ b/.github/workflows/juno_typing_test.yaml
@@ -18,15 +18,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setting up conda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          mamba-version: "0.25.0"
-          channels: bioconda, biocore, conda-forge, anaconda
-          channel-priority: true
-          environment-file: envs/master_env.yaml 
-          activate-environment: juno_typing
-          auto-activate-base: false
+          cache-downloads: true
+          environment-file: envs/master_env.yaml
       - name: Conda list
         shell: bash -l {0}
         run: conda list

--- a/.github/workflows/juno_typing_test.yaml
+++ b/.github/workflows/juno_typing_test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setting up conda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          mamba-version: "0.15.3"
+          mamba-version: "0.25.0"
           channels: bioconda, biocore, conda-forge, anaconda
           channel-priority: true
           environment-file: envs/master_env.yaml 

--- a/bin/rules/serotype.smk
+++ b/bin/rules/serotype.smk
@@ -174,13 +174,13 @@ rule shigatyper:
 
         shigatyper {input.r1} {input.r2} > "$(basename {output.command_out})" 2> {log}
 
-        for file in *.csv
-        do 
-            file_stem=$(echo ${{file%\.*}})
-            if [[ {wildcards.sample} = *"$file_stem"* ]]; then
-                mv "${{file}}" "${{file/*/shigatyper.csv}}"
-            fi
-        done
+        if [ -f {wildcards.sample}.csv ]
+        then
+            mv {wildcards.sample}.csv shigatyper.csv
+        else
+            # save header without data in expected output file
+            echo ",Hit,Number of reads,Length Covered,reference length,% covered,Number of variants,% accuracy" > shigatyper.csv
+        fi
         """
 
 

--- a/envs/master_env.yaml
+++ b/envs/master_env.yaml
@@ -1,9 +1,9 @@
 name: juno_typing
 channels:
+  - anaconda
   - bioconda
   - biocore
   - conda-forge
-  - anaconda
 dependencies:
   - python>=3.8.*
   - snakemake>=7.14.*

--- a/envs/master_env.yaml
+++ b/envs/master_env.yaml
@@ -1,9 +1,9 @@
 name: juno_typing
 channels:
+  - conda-forge
   - anaconda
   - bioconda
   - biocore
-  - conda-forge
 dependencies:
   - python>=3.8.*
   - snakemake>=7.14.*


### PR DESCRIPTION
Shigatyper does not output a `{wildcards.sample}.csv` file if no targets are identified, which crashes Snakemake. This file is now created containing just the header if no targets are found.

This was noted for an RIVM ST3075 isolate and could be reproduced with a public ST3075 isolate (SRR22520737).