### PR TITLE
fix: dont check for blast file

### DIFF
--- a/bin/rules/serotype.smk
+++ b/bin/rules/serotype.smk
@@ -55,8 +55,7 @@ rule salmonella_serotyper:
     output:
         seqsero=OUT + "/serotype/{sample}/SeqSero_result.tsv",
         seqsero_tmp1=temp(OUT + "/serotype/{sample}/SeqSero_result.txt"),
-        seqsero_tmp2=temp(OUT + "/serotype/{sample}/blasted_output.xml"),
-        seqsero_tmp3=temp(OUT + "/serotype/{sample}/data_log.txt"),
+        seqsero_tmp2=temp(OUT + "/serotype/{sample}/data_log.txt"),
     message:
         "Running Salmonella serotyper for {wildcards.sample}."
     log:


### PR DESCRIPTION
Remove checking if the `blasted_output.xml` file is present at completion of seqsero2 rule. If no serotype is detected for an isolate, this file is not present at completion. This should not crash the pipeline. 