### PR TITLE
upgrade to pyopenssl>=24

### DIFF
--- a/envs/juno_typing.yaml
+++ b/envs/juno_typing.yaml
@@ -27,5 +27,6 @@ dependencies:
   - blast=2.12.0
   - pip=23.*
   - pulp=2.7.0
+  - pyopenssl>=24.0.0
   - pip:
     - "--editable=git+https://github.com/RIVM-bioinformatics/juno-library.git@v2.0.1#egg=juno_library"


### PR DESCRIPTION
resolves this error
```
    class X509StoreFlags(object):
  File "/mnt/irodsscratch/pipelines/prod/8251a9ef/.conda/envs/pipeline_env/lib/python3.9/site-packages/OpenSSL/crypto.py", line 1598, in X509StoreFlags
    NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'
```
(https://github.com/conda/conda/issues/13619)
