### PR TITLE
fix: make neisseria_capsule_DB source path configurable (closes #48)

### DIFF
--- a/bin/download_dbs.py
+++ b/bin/download_dbs.py
@@ -19,11 +19,13 @@ class DownloadsJunoTyping:
         serotypefinder_db_asked_version="master",
         seroba_db_asked_version="master",
         seroba_kmersize=71,
+        neisseria_db_source="/mnt/db/juno/neisseria_capsule_DB",
     ):
         self.db_dir = pathlib.Path(db_dir)
         self.bin_dir = pathlib.Path(__file__).parent.absolute()
         self.update_dbs = update_dbs
         self.seroba_kmersize = seroba_kmersize
+        self.neisseria_db_source = pathlib.Path(neisseria_db_source)
         self.downloaded_versions = self.get_downloads_juno_typing(
             cge_mlst_asked_version=cge_mlst_asked_version,
             characterize_neisseria_capsule_asked_version=characterize_neisseria_capsule_asked_version,
@@ -103,24 +105,27 @@ class DownloadsJunoTyping:
         return version
 
     def copy_neisseria_db(self):
-        """Function to copy the neisseria db from mnt/db/juno to the bin folder of the neisseria tool.
-        It is necessary for the tool to run the database from this location."""
+        """Copy the neisseria capsule DB into the characterize_neisseria_capsule bin folder."""
         characterize_neisseria_capsule_db_dir = self.bin_dir.joinpath(
             "characterize_neisseria_capsule"
         )
-        if not characterize_neisseria_capsule_db_dir.joinpath(
-            "neisseria_capsule_DB"
-        ).exists():
+        destination = characterize_neisseria_capsule_db_dir.joinpath("neisseria_capsule_DB")
+        if not destination.exists():
+            if not self.neisseria_db_source.exists():
+                raise FileNotFoundError(
+                    f"Neisseria capsule DB source not found at {self.neisseria_db_source}. "
+                    "Pass --neisseria_db_source to override the default."
+                )
             try:
                 print(
-                    f"Copying neisseria db from /mnt/db/juno to: {characterize_neisseria_capsule_db_dir}"
+                    f"Copying neisseria db from {self.neisseria_db_source} to: {destination}"
                 )
                 build = subprocess.run(
                     [
                         "cp",
                         "-R",
-                        "/mnt/db/juno/neisseria_capsule_DB",
-                        f"{characterize_neisseria_capsule_db_dir}",
+                        str(self.neisseria_db_source),
+                        str(destination),
                     ],
                     cwd=str(characterize_neisseria_capsule_db_dir),
                     check=True,
@@ -129,7 +134,7 @@ class DownloadsJunoTyping:
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as err:
                 build.kill()
                 raise Exception(
-                    "Error building neisseria db, this currently only works on RIVM HPC"
+                    f"Error copying neisseria db from {self.neisseria_db_source}"
                 ) from err
         else:
             return print("Neisseria db is available, continue analysis")
@@ -303,6 +308,12 @@ if __name__ == "__main__":
         default=71,
         help="Kmer size to be used to build Seroba's database.",
     )
+    argument_parser.add_argument(
+        "--neisseria-db-source",
+        type=pathlib.Path,
+        default=pathlib.Path("/mnt/db/juno/neisseria_capsule_DB"),
+        help="Source path for the neisseria_capsule_DB.",
+    )
     argument_parser.add_argument("--update", dest="update_dbs", action="store_true")
     args = argument_parser.parse_args()
     downloads = DownloadsJunoTyping(
@@ -314,5 +325,6 @@ if __name__ == "__main__":
         serotypefinder_db_asked_version=args.serotypefinder_db_version,
         seroba_db_asked_version=args.seroba_db_version,
         seroba_kmersize=args.seroba_kmer_size,
+        neisseria_db_source=args.neisseria_db_source,
     )
     print(downloads.downloaded_versions)

--- a/juno_typing.py
+++ b/juno_typing.py
@@ -115,6 +115,13 @@ class JunoTyping(Pipeline):
             help="Name for the directory containing the Bordetella vaccine antigen MLST scheme in --db_dir. Should contain a BLAST db with base name bordetella.fa",
         )
         self.add_argument(
+            "--neisseria_db_source",
+            type=Path,
+            metavar="DIR",
+            default=Path("/mnt/db/juno/neisseria_capsule_DB"),
+            help="Source path for the neisseria_capsule_DB.",
+        )
+        self.add_argument(
             "--update",
             action="store_true",
             help="Force database update even if they are present.",
@@ -147,6 +154,7 @@ class JunoTyping(Pipeline):
             args.bordetella_vaccine_antigen_scheme_name
         )
         self.update_dbs: bool = args.update
+        self.neisseria_db_source: Path = args.neisseria_db_source
         self.seqsero_context: Path = args.seqsero_context
         return args
 
@@ -244,6 +252,7 @@ class JunoTyping(Pipeline):
                 mlst7_db_asked_version="master",
                 serotypefinder_db_asked_version="master",
                 seroba_db_asked_version="master",
+                neisseria_db_source=self.neisseria_db_source,
             )
             self.downloads_versions = downloads_juno_typing.downloaded_versions
             with open(

--- a/tests/test_juno_typing.py
+++ b/tests/test_juno_typing.py
@@ -1,5 +1,7 @@
 import csv
 import os
+import shutil
+import tempfile
 from pathlib import Path
 from sys import path
 import unittest
@@ -58,6 +60,65 @@ class TestDownloadDbs(unittest.TestCase):
         self.assertTrue(
             path_to_db.joinpath("seroba_db", "database", "cdhit_cluster").exists()
         )
+
+
+class TestCopyNeisseriaDb(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.fake_source = self.tmp / "neisseria_capsule_DB"
+        self.fake_source.mkdir()
+        (self.fake_source / "marker.txt").write_text("hello")
+        self.fake_bin = self.tmp / "bin"
+        (self.fake_bin / "characterize_neisseria_capsule").mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp)
+
+    def _make_instance(self, source: Path) -> DownloadsJunoTyping:
+        instance = DownloadsJunoTyping.__new__(DownloadsJunoTyping)
+        instance.bin_dir = self.fake_bin
+        instance.neisseria_db_source = source
+        return instance
+
+    def test_copies_from_overridden_source(self) -> None:
+        instance = self._make_instance(self.fake_source)
+        instance.copy_neisseria_db()
+        copied_marker = (
+            self.fake_bin
+            / "characterize_neisseria_capsule"
+            / "neisseria_capsule_DB"
+            / "marker.txt"
+        )
+        self.assertTrue(copied_marker.exists())
+        self.assertEqual(copied_marker.read_text(), "hello")
+
+    def test_copies_from_arbitrarily_named_source(self) -> None:
+        renamed = self.tmp / "my_custom_db"
+        renamed.mkdir()
+        (renamed / "marker.txt").write_text("hello")
+        instance = self._make_instance(renamed)
+        instance.copy_neisseria_db()
+        copied_marker = (
+            self.fake_bin
+            / "characterize_neisseria_capsule"
+            / "neisseria_capsule_DB"
+            / "marker.txt"
+        )
+        self.assertTrue(copied_marker.exists())
+
+    def test_missing_source_raises_clear_error(self) -> None:
+        instance = self._make_instance(self.tmp / "does_not_exist")
+        with self.assertRaises(FileNotFoundError) as ctx:
+            instance.copy_neisseria_db()
+        self.assertIn("does_not_exist", str(ctx.exception))
+
+    def test_default_preserves_rivm_hpc_path(self) -> None:
+        import inspect
+        default = inspect.signature(
+            DownloadsJunoTyping.__init__
+        ).parameters["neisseria_db_source"].default
+        self.assertEqual(str(default), "/mnt/db/juno/neisseria_capsule_DB")
 
 
 class TestJunoTypingDryRun(unittest.TestCase):


### PR DESCRIPTION
Closes #48.

Adds a `neisseria_db_source` parameter to `DownloadsJunoTyping.__init__`, defaulting to the existing `/mnt/db/juno/neisseria_capsule_DB`, and threads it through `copy_neisseria_db`. Exposed on both `juno_typing.py` and `bin/download_dbs.py`. RIVM HPC behaviour unchanged.

Went with a CLI flag because that's what the sister juno-* pipelines do for their `/mnt/db/juno/...` defaults; I read "configuration file" in the issue loosely on that basis. If you'd prefer YAML, a natural follow-up would be pulling the other hardcoded source URLs (kmerfinder, mlst, seroba, ...) into one `config/db_sources.yaml`. Either's fine, just say.

Also added a `FileNotFoundError` pre-flight so off-HPC users get a clear message instead of the wrapped subprocess error.

Tests cover the override path, the missing-source error, and pin the default so a future refactor can't silently move it.

Unrelated, but worth its own ticket: several `download_*` / `copy_*` methods have

```python
try:
    build = subprocess.run(...)
except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as err:
    build.kill()
    ...
```

`subprocess.run` is what raises those two exceptions, so `build` was never assigned; the handler fires `UnboundLocalError` and shadows the real error. Same shape in at least `download_db_kmerfinder`, `download_db_mlst7`, and `copy_neisseria_db`. Happy to file it separately.
